### PR TITLE
Switch default stopPort to 8079 to match the idiomatic port at http://do...

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/gae/GaePluginConvention.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gae/GaePluginConvention.groovy
@@ -25,7 +25,7 @@ import org.gradle.api.plugins.gae.task.appcfg.GaeAppConfigConvention
 class GaePluginConvention {
     String httpAddress
     Integer httpPort = 8080
-    Integer stopPort = 8081
+    Integer stopPort = 8079
     String stopKey
     Boolean daemon = false
     Boolean disableUpdateCheck = false


### PR DESCRIPTION
...cs.codehaus.org/display/JETTY/Securing+Jetty and to avoid a conflict with gradle --daemon
