### PR TITLE
Remove "optimizeWar = true" from the example build.gradle file because i...

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ The task `gaeUpdate` allows you to specify upload specific settings. Define the 
 
     gae {
         httpPort = 8085
-        optimizeWar = true
 
         appcfg {
             email = 'benjamin.muschko@gmail.com'


### PR DESCRIPTION
...t causes the build to take a long time and can cause warnings in dev_appserver. See http://wtanaka.com/node/8082
