### PR TITLE
Add compile classpath to appengineEnhance task

### DIFF
--- a/src/main/groovy/com/google/appengine/task/EnhanceTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/EnhanceTask.groovy
@@ -42,7 +42,7 @@ class EnhanceTask extends WebAppDirTask {
                     pathelement(path: System.getProperty(JAVA_CLASSPATH_SYS_PROP_KEY))
                     pathelement(path: getClassesDirectory().canonicalPath)
                     fileset(dir: "${getWebAppSourceDirectory().canonicalPath}/WEB-INF/lib", erroronmissingdir: "false", includes: '*.jar')
-					pathelement(path: project.configurations.compile.asPath)
+                    pathelement(path: project.configurations.compile.asPath)
                 }
                 fileset(dir: getClassesDirectory().canonicalPath, includes: '**/*.class')
             }


### PR DESCRIPTION
Fixes bug with appengineEnhance ignoring the configured compile classpath. Without this bug fix, the only way to get enhance to see 3rd party dependencies is to store the jars in the source folder for WEB-INF/lib, which is undesirable n a gradle based build.
