### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ example on how to retrieve it from Maven Central:
         }
     }
 
-*Note:* The plugin requires you to set the environment variable _APPENGINE_HOME_ or the system property _appengine.sdk.root_
+*Note:* The plugin requires you to set the environment variable APPENGINE_HOME or the system property _appengine.sdk.root_
 pointing to your current Google App Engine SDK installation. In case you have both variables set the system property takes
 precedence over the environment variable. Alternatively, you can choose to automatically download the SDK by setting the
 convention property `downloadSdk` to `true`. This option requires you to specify the SDK version you want to use by setting


### PR DESCRIPTION
Fixed markdown formatting issue with the use of underscores, that was hiding the proper underscore in the APPENGINE_HOME env. variable. Before it was italicizing the APPENGINE part and showing an underscore after HOME, now it at least displays the proper letters, if not italicized. (Appears you can't italicize a work with an underscore in it in github markdown.
