### PR TITLE
Adjustment for configureOnDemand bug with projectEvaluated

### DIFF
--- a/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
@@ -499,7 +499,7 @@ class AppEnginePlugin implements Plugin<Project> {
         endpointsExportClientLibs.group = APPENGINE_GROUP
         endpointsExportClientLibs.dependsOn(endpointsGetClientLibs)
 
-        project.gradle.projectsEvaluated {
+        project.afterEvaluate {
             if(appEnginePluginConvention.endpoints.getDiscoveryDocsOnBuild) {
                 project.tasks.getByName(WarPlugin.WAR_TASK_NAME).dependsOn(endpointsGetDiscoveryDocs)
             }


### PR DESCRIPTION
This fixes an issue when configureOnDemand is used in gradle.properties (this option is used by android studio)
