### PR TITLE
release 1.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ example on how to retrieve it from Maven Central:
         }
 
         dependencies {
-            classpath 'com.google.appengine:gradle-appengine-plugin:1.9.10'
+            classpath 'com.google.appengine:gradle-appengine-plugin:1.9.11'
         }
     }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 1.9.11 (Sept 12th, 2014)
+* Change configuration from convention to extension
+* Add in gcloud plugin and commands (gcloudAppRun, gcloudAppDeploy, generic gcloudTask)
+* Update build to use gradle 2.1
+
 ### Version 1.9.10 (August 29th, 2014)
 * Version number match release
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ def compatibilityVersion = 1.7
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion
 group = 'com.google.appengine'
-version = '1.9.10'
+version = '1.9.11'
 
 buildscript {
     repositories {


### PR DESCRIPTION
depends on https://github.com/GoogleCloudPlatform/gradle-appengine-plugin/pull/117 and https://github.com/GoogleCloudPlatform/gradle-appengine-plugin/pull/120
