### PR TITLE
Fix bug that would cause import failures in Intellij

### DIFF
--- a/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
@@ -44,7 +44,6 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 import org.gradle.plugins.ear.EarPluginConvention
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
-import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
 import javax.inject.Inject
@@ -625,20 +624,9 @@ class AppEnginePlugin implements Plugin<Project> {
         functionalSourceSet.compileClasspath = mainSourceSet.output + functionalTestCompileConfiguration
         functionalSourceSet.runtimeClasspath = functionalSourceSet.output + functionalTestRuntimeConfiguration
 
-        addIdeaConfigurationForFunctionalTestSourceSet(project, functionalTestCompileConfiguration, functionalTestRuntimeConfiguration, functionalSourceSet)
         addEclipseConfigurationForFunctionalTestRuntimeConfiguration(project, functionalTestRuntimeConfiguration)
 
         functionalSourceSet
-    }
-
-    private void addIdeaConfigurationForFunctionalTestSourceSet(Project project, Configuration compile, Configuration runtime, SourceSet sourceSet) {
-        project.plugins.withType(IdeaPlugin) { IdeaPlugin plugin ->
-            plugin.model.module {
-                testSourceDirs += sourceSet.allSource.srcDirs
-                scopes.TEST.plus += compile
-                scopes.TEST.plus += runtime
-            }
-        }
     }
 
     private void addEclipseConfigurationForFunctionalTestRuntimeConfiguration(Project project, Configuration functionalTestRuntimeConfiguration) {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/gradle-appengine-plugin/issues/124
We don't need the idea plugin anymore as the Gradle import functionality
in intellij reads state from gradle directly.
