### PR TITLE
Add in check for Gradle Version >= 2.1

### DIFF
--- a/src/test/groovy/com/google/appengine/AppEnginePluginTest.groovy
+++ b/src/test/groovy/com/google/appengine/AppEnginePluginTest.groovy
@@ -1,0 +1,36 @@
+package com.google.appengine
+
+import org.gradle.tooling.BuildException
+import spock.lang.Specification
+
+/**
+ * Tests for the AppEnginePlugin
+ */
+class AppEnginePluginTest extends Specification {
+
+    def "Check version below minimum"() {
+        given:
+            String gradleVersionLow = "1.0"
+
+        when:
+            AppEnginePlugin.checkGradleVersion(gradleVersionLow)
+
+        then:
+            thrown BuildException
+    }
+
+    def "Check version ok"() {
+        given:
+            String gradleVersionEqual = AppEnginePlugin.GRADLE_MIN_VERSION
+            String gradleVersionHigh = "1" + AppEnginePlugin.GRADLE_MIN_VERSION
+
+        when:
+            AppEnginePlugin.checkGradleVersion(gradleVersionEqual)
+            AppEnginePlugin.checkGradleVersion(gradleVersionHigh)
+
+        then:
+            notThrown BuildException
+    }
+
+}
+


### PR DESCRIPTION
Add a version check so users don't get a terrible error about shortTypeHandling when using gradle1.12, etc
