### PR TITLE
Change GString to String for tooling JVM Args list

### DIFF
--- a/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
+++ b/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
@@ -58,7 +58,7 @@ public class AppEngineToolingBuilderModel implements ToolingModelBuilder {
                                          conf.disableUpdateCheck,
                                          conf.enhancer.version,
                                          conf.enhancer.api,
-                                         conf.jvmFlags,
+                                         conf.jvmFlags*.toString(), // convert everything to a java string
                                          conf.warDir ?: AppEnginePlugin.getExplodedAppDirectory(project),
                                          AppEnginePlugin.getAppDir(project),
                                          getSdkLocation(conf, project),


### PR DESCRIPTION
Tooling for gradle import throws a type mismatch error if we don't ensure these are Java Strings.
