### PR TITLE
[gradle-appengine-plugin] Don't require a free UDP port.

### DIFF
--- a/builder-model/src/main/java/com/google/appengine/gradle/model/AppEngineModel.java
+++ b/builder-model/src/main/java/com/google/appengine/gradle/model/AppEngineModel.java
@@ -27,6 +27,7 @@ public interface AppEngineModel {
     public String getHttpAddress();
     public Integer getHttpPort();
     public Boolean isDisableUpdateCheck();
+    public Boolean isDisableDatagram();
     public String getEnhancerVersion();
     public String getEnhancerApi();
     public List<String> getJvmFlags();

--- a/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
@@ -282,6 +282,7 @@ class AppEnginePlugin implements Plugin<Project> {
             appengineRunTask.conventionMapping.map('httpPort') { appEnginePluginExtension.httpPort }
             appengineRunTask.conventionMapping.map('daemon') { appEnginePluginExtension.daemon }
             appengineRunTask.conventionMapping.map('disableUpdateCheck') { appEnginePluginExtension.disableUpdateCheck }
+            appengineRunTask.conventionMapping.map('disableDatagram') { appEnginePluginExtension.disableDatagram }
             appengineRunTask.conventionMapping.map('jvmFlags') { appEnginePluginExtension.jvmFlags }
             appengineRunTask.conventionMapping.map(EXPLODED_WAR_DIR_CONVENTION_PARAM) { appEnginePluginExtension.warDir ?: explodedAppDirectory }
         }

--- a/src/main/groovy/com/google/appengine/AppEnginePluginExtension.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePluginExtension.groovy
@@ -30,6 +30,7 @@ class AppEnginePluginExtension {
     Integer httpPort = 8080
     Boolean daemon = false
     Boolean disableUpdateCheck = false
+    Boolean disableDatagram = false
     List<String> jvmFlags = []
     File warDir
     Boolean downloadSdk = false

--- a/src/main/groovy/com/google/appengine/task/RunTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/RunTask.groovy
@@ -33,6 +33,7 @@ class RunTask extends AbstractTask implements Explodable {
     File explodedAppDirectory
     Boolean daemon
     Boolean disableUpdateCheck
+    Boolean disableDatagram
     List<String> jvmFlags
     final KickStartSynchronizer kickStartSynchronizer = new KickStartSynchronizer()
     private static final String DEV_SERVER_STARTED = 'Dev App Server is now running'
@@ -48,7 +49,7 @@ class RunTask extends AbstractTask implements Explodable {
             throw new InvalidUserDataException("Invalid $type port number: $port")
         }
 
-        if(!PortUtility.isAvailable(port)) {
+        if(!PortUtility.isAvailable(port, disableDatagram)) {
             throw new InvalidUserDataException("$type port number already in use: $port")
         }
 
@@ -90,6 +91,7 @@ class RunTask extends AbstractTask implements Explodable {
         kickStartParams.httpPort = getHttpPort()
         kickStartParams.httpAddress = getHttpAddress()
         kickStartParams.disableUpdateCheck = getDisableUpdateCheck()
+        kickStartParams.disableDatagram = getDisableDatagram()
         kickStartParams.jvmFlags = getJvmFlags()
         kickStartParams.explodedWarDirectory = getExplodedAppDirectory()
 

--- a/src/main/groovy/com/google/appengine/task/internal/KickStartParams.groovy
+++ b/src/main/groovy/com/google/appengine/task/internal/KickStartParams.groovy
@@ -24,6 +24,7 @@ class KickStartParams {
     String httpAddress
     Integer httpPort
     Boolean disableUpdateCheck
+    Boolean disableDatagram
     List<String> jvmFlags
     File explodedWarDirectory
 }

--- a/src/main/groovy/com/google/appengine/task/internal/KickStartParamsBuilder.groovy
+++ b/src/main/groovy/com/google/appengine/task/internal/KickStartParamsBuilder.groovy
@@ -26,6 +26,7 @@ class KickStartParamsBuilder {
     static final String ADDRESS = '--address'
     static final String PORT = '--port'
     static final String DISABLE_UPDATE_CHECK = '--disable_update_check'
+    static final String DISABLE_DATAGRAM = '--disable_datagram'
     static final String JVM_FLAG = '--jvm_flag'
     static final String REMOTE_SHUTDOWN_FLAG = "--allow_remote_shutdown"
 
@@ -44,6 +45,10 @@ class KickStartParamsBuilder {
 
         if(kickStartParams.disableUpdateCheck) {
             params << DISABLE_UPDATE_CHECK
+        }
+
+        if (kickStartParams.disableDatagram) {
+          params << DISABLE_DATAGRAM
         }
 
         params << REMOTE_SHUTDOWN_FLAG

--- a/src/main/groovy/com/google/appengine/task/internal/PortUtility.groovy
+++ b/src/main/groovy/com/google/appengine/task/internal/PortUtility.groovy
@@ -40,17 +40,22 @@ final class PortUtility {
      * Checks if port is available.
      *
      * @param port Port
+     * @param disableDatagram {@code true} if UDP socket not needed or wanted.
+     *        Useful when running on Jenkins where its plugin is not able to
+     *        assign a free port available for both TCP and UDP.
      * @return Flag
      */
-    static boolean isAvailable(Integer port) {
+    static boolean isAvailable(Integer port, Boolean disableDatagram) {
         ServerSocket ss
         DatagramSocket ds
 
         try {
             ss = new ServerSocket(port, 0, InetAddress.getByName('127.0.0.1'))
             ss.reuseAddress = true
-            ds = new DatagramSocket(port, InetAddress.getByName('127.0.0.1'))
-            ds.reuseAddress = true
+            if (!disableDatagram) {
+              ds = new DatagramSocket(port, InetAddress.getByName('127.0.0.1'))
+              ds.reuseAddress = true
+            }
             return true
         }
         catch(IOException e) {

--- a/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
+++ b/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
@@ -56,6 +56,7 @@ public class AppEngineToolingBuilderModel implements ToolingModelBuilder {
         return new DefaultAppEngineModel(conf.httpAddress,
                                          conf.httpPort,
                                          conf.disableUpdateCheck,
+                                         conf.disableDatagram,
                                          conf.enhancer.version,
                                          conf.enhancer.api,
                                          conf.jvmFlags*.toString(), // convert everything to a java string

--- a/src/model/java/com/google/appengine/gradle/model/impl/DefaultAppEngineModel.java
+++ b/src/model/java/com/google/appengine/gradle/model/impl/DefaultAppEngineModel.java
@@ -29,6 +29,7 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     final private String httpAddress;
     final private Integer httpPort;
     final private Boolean disableUpdateCheck;
+    final private Boolean disableDatagram;
     final private String enhancerVersion;
     final private String enhancerApi;
     final private List<String> jvmFlags;
@@ -38,11 +39,13 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     final private AppCfgOptions appCfgOptions;
 
     public DefaultAppEngineModel(String httpAddress, Integer httpPort, Boolean disableUpdateCheck,
+                                 Boolean disableDatagram,
                                  String enhancerVersion, String enhancerApi, List<String> jvmFlags, File warDir,
                                  File webAppDir, String sdkRoot, AppCfgOptions appCfgOptions) {
         this.httpAddress = httpAddress;
         this.httpPort = httpPort;
         this.disableUpdateCheck = disableUpdateCheck;
+        this.disableDatagram = disableDatagram;
         this.enhancerVersion = enhancerVersion;
         this.enhancerApi = enhancerApi;
         this.jvmFlags = jvmFlags;
@@ -70,6 +73,11 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     @Override
     public Boolean isDisableUpdateCheck() {
         return disableUpdateCheck;
+    }
+
+    @Override
+    public Boolean isDisableDatagram() {
+        return disableDatagram;
     }
 
     @Override

--- a/src/test/groovy/com/google/appengine/task/internal/KickStartParamsBuilderTest.groovy
+++ b/src/test/groovy/com/google/appengine/task/internal/KickStartParamsBuilderTest.groovy
@@ -55,6 +55,23 @@ class KickStartParamsBuilderTest extends Specification {
             params.get(4) == '/dev/main/war'
     }
 
+    def "Build parameters for minimal arguments plus disable datagram"() {
+        given: "no extra arguments are provided"
+            KickStartParams kickStartParams = createBasicParams()
+            kickStartParams.disableDatagram = true
+
+        when: "the params are built"
+            List<String> params = KickStartParamsBuilder.instance.buildCommandLineParams(kickStartParams)
+
+        then: "the basic parameters are set up"
+            params.size() == 5
+            params.get(0) == KickStartParamsBuilder.MAIN_CLASS
+            params.get(1) == "$KickStartParamsBuilder.PORT=8080"
+            params.get(2) == KickStartParamsBuilder.DISABLE_DATAGRAM
+            params.get(3) == KickStartParamsBuilder.REMOTE_SHUTDOWN_FLAG
+            params.get(4) == '/dev/main/war'
+    }
+
     def "Build parameters for minimal arguments plus disable update check, httAddress and additional JVM flags"() {
         given: "no extra arguments are provided"
             KickStartParams kickStartParams = createBasicParams()


### PR DESCRIPTION
The Jenkins Port Allocator Plugin is not able to assign a free UDP port.
The current appengineRun task implementation fails unless it can find
a port number that has both TCP and UDP free. Since Jenkins only
confirms that the TCP port is free, this causes Jenkins to repeatedly
assign a failing port to our builds.

This change introduces a new convention/extension property that can be
specified to disable the need for a free Datagram/UDP socket.

TESTED:
- Wrote builder test to make sure params passed.
- Used new plugin with disableDatagram property specified to execute
  appengineRun task.
