### PR TITLE
Finalize the functional test task with server stop

### DIFF
--- a/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
@@ -625,6 +625,7 @@ class AppEnginePlugin implements Plugin<Project> {
         appengineFunctionalTest.testClassesDir = functionalSourceSet.output.classesDir
         appengineFunctionalTest.classpath = functionalSourceSet.runtimeClasspath
         appengineFunctionalTest.dependsOn(project.tasks.getByName(APPENGINE_RUN))
+        appengineFunctionalTest.finalizedBy(project.tasks.getByName(APPENGINE_STOP))
 
         project.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
             if(taskGraph.hasTask(appengineFunctionalTest)) {

--- a/src/main/groovy/com/google/appengine/task/StopTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/StopTask.groovy
@@ -41,7 +41,7 @@ class StopTask extends DefaultTask {
             connection.getOutputStream().write(0);
             BufferedReader responseReader = new BufferedReader(new InputStreamReader(connection.getInputStream()))
             while(responseReader.readLine() != null);
-            logger.lifecycle("Shutting down devappserver on port : " + getHttpPort());
+            logger.info("Shutting down devappserver on port : " + getHttpPort());
             Thread.sleep(2000);
         } catch (MalformedURLException e) {
             throw new GradleScriptException("URL malformed attempting to stop the devappserver : " + e.getMessage(), e);


### PR DESCRIPTION
This ensures the server that is started for functional tests is stopped
and doesn't depend on the ending of the daemon process as the mechanism
for killing the server.

Fix for #145