### PR TITLE
Fix issue introduced in Change d866b74bc648a56a50909670691b8566cf2a45e3.

### DIFF
--- a/src/main/groovy/com/google/appengine/task/RunTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/RunTask.groovy
@@ -91,7 +91,6 @@ class RunTask extends AbstractTask implements Explodable {
         kickStartParams.httpPort = getHttpPort()
         kickStartParams.httpAddress = getHttpAddress()
         kickStartParams.disableUpdateCheck = getDisableUpdateCheck()
-        kickStartParams.disableDatagram = getDisableDatagram()
         kickStartParams.jvmFlags = getJvmFlags()
         kickStartParams.explodedWarDirectory = getExplodedAppDirectory()
 

--- a/src/main/groovy/com/google/appengine/task/internal/KickStartParams.groovy
+++ b/src/main/groovy/com/google/appengine/task/internal/KickStartParams.groovy
@@ -24,7 +24,6 @@ class KickStartParams {
     String httpAddress
     Integer httpPort
     Boolean disableUpdateCheck
-    Boolean disableDatagram
     List<String> jvmFlags
     File explodedWarDirectory
 }

--- a/src/main/groovy/com/google/appengine/task/internal/KickStartParamsBuilder.groovy
+++ b/src/main/groovy/com/google/appengine/task/internal/KickStartParamsBuilder.groovy
@@ -26,7 +26,6 @@ class KickStartParamsBuilder {
     static final String ADDRESS = '--address'
     static final String PORT = '--port'
     static final String DISABLE_UPDATE_CHECK = '--disable_update_check'
-    static final String DISABLE_DATAGRAM = '--disable_datagram'
     static final String JVM_FLAG = '--jvm_flag'
     static final String REMOTE_SHUTDOWN_FLAG = "--allow_remote_shutdown"
 
@@ -45,10 +44,6 @@ class KickStartParamsBuilder {
 
         if(kickStartParams.disableUpdateCheck) {
             params << DISABLE_UPDATE_CHECK
-        }
-
-        if (kickStartParams.disableDatagram) {
-          params << DISABLE_DATAGRAM
         }
 
         params << REMOTE_SHUTDOWN_FLAG

--- a/src/test/groovy/com/google/appengine/task/internal/KickStartParamsBuilderTest.groovy
+++ b/src/test/groovy/com/google/appengine/task/internal/KickStartParamsBuilderTest.groovy
@@ -55,23 +55,6 @@ class KickStartParamsBuilderTest extends Specification {
             params.get(4) == '/dev/main/war'
     }
 
-    def "Build parameters for minimal arguments plus disable datagram"() {
-        given: "no extra arguments are provided"
-            KickStartParams kickStartParams = createBasicParams()
-            kickStartParams.disableDatagram = true
-
-        when: "the params are built"
-            List<String> params = KickStartParamsBuilder.instance.buildCommandLineParams(kickStartParams)
-
-        then: "the basic parameters are set up"
-            params.size() == 5
-            params.get(0) == KickStartParamsBuilder.MAIN_CLASS
-            params.get(1) == "$KickStartParamsBuilder.PORT=8080"
-            params.get(2) == KickStartParamsBuilder.DISABLE_DATAGRAM
-            params.get(3) == KickStartParamsBuilder.REMOTE_SHUTDOWN_FLAG
-            params.get(4) == '/dev/main/war'
-    }
-
     def "Build parameters for minimal arguments plus disable update check, httAddress and additional JVM flags"() {
         given: "no extra arguments are provided"
             KickStartParams kickStartParams = createBasicParams()


### PR DESCRIPTION
Carried the new parameter/field into the kick start parameters where it was
being sent to the underlaying DevAppServerMain. Of course that class doesn't
know about this parameter and doesn't care.

This change removes the addition of the parameter to the KickStartParams and all
related usage of it.

TESTED:
- Discovered this by using the new disableDatagram property within an appengine
  task declaration on a project that has a functional test that requires the
  DevAppServer to be started. Server start would fail with a warning that an
  unknown option (--disable_datagram) was being used.
- Ran the same project against a local publication of the AppEngine Plugin built
  from this patch and the test ran fine.