### PR TITLE
Remove more unused code for disableDatagram.

### DIFF
--- a/builder-model/src/main/java/com/google/appengine/gradle/model/AppEngineModel.java
+++ b/builder-model/src/main/java/com/google/appengine/gradle/model/AppEngineModel.java
@@ -27,7 +27,6 @@ public interface AppEngineModel {
     public String getHttpAddress();
     public Integer getHttpPort();
     public Boolean isDisableUpdateCheck();
-    public Boolean isDisableDatagram();
     public String getEnhancerVersion();
     public String getEnhancerApi();
     public List<String> getJvmFlags();

--- a/src/main/groovy/com/google/appengine/task/RunTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/RunTask.groovy
@@ -49,7 +49,7 @@ class RunTask extends AbstractTask implements Explodable {
             throw new InvalidUserDataException("Invalid $type port number: $port")
         }
 
-        if(!PortUtility.isAvailable(port, disableDatagram)) {
+        if(!PortUtility.isAvailable(port, getDisableDatagram())) {
             throw new InvalidUserDataException("$type port number already in use: $port")
         }
 

--- a/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
+++ b/src/main/groovy/com/google/appengine/tooling/AppEngineToolingBuilderModel.groovy
@@ -56,7 +56,6 @@ public class AppEngineToolingBuilderModel implements ToolingModelBuilder {
         return new DefaultAppEngineModel(conf.httpAddress,
                                          conf.httpPort,
                                          conf.disableUpdateCheck,
-                                         conf.disableDatagram,
                                          conf.enhancer.version,
                                          conf.enhancer.api,
                                          conf.jvmFlags*.toString(), // convert everything to a java string

--- a/src/model/java/com/google/appengine/gradle/model/impl/DefaultAppEngineModel.java
+++ b/src/model/java/com/google/appengine/gradle/model/impl/DefaultAppEngineModel.java
@@ -29,7 +29,6 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     final private String httpAddress;
     final private Integer httpPort;
     final private Boolean disableUpdateCheck;
-    final private Boolean disableDatagram;
     final private String enhancerVersion;
     final private String enhancerApi;
     final private List<String> jvmFlags;
@@ -39,13 +38,11 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     final private AppCfgOptions appCfgOptions;
 
     public DefaultAppEngineModel(String httpAddress, Integer httpPort, Boolean disableUpdateCheck,
-                                 Boolean disableDatagram,
                                  String enhancerVersion, String enhancerApi, List<String> jvmFlags, File warDir,
                                  File webAppDir, String sdkRoot, AppCfgOptions appCfgOptions) {
         this.httpAddress = httpAddress;
         this.httpPort = httpPort;
         this.disableUpdateCheck = disableUpdateCheck;
-        this.disableDatagram = disableDatagram;
         this.enhancerVersion = enhancerVersion;
         this.enhancerApi = enhancerApi;
         this.jvmFlags = jvmFlags;
@@ -73,11 +70,6 @@ public class DefaultAppEngineModel implements AppEngineModel, Serializable {
     @Override
     public Boolean isDisableUpdateCheck() {
         return disableUpdateCheck;
-    }
-
-    @Override
-    public Boolean isDisableDatagram() {
-        return disableDatagram;
     }
 
     @Override


### PR DESCRIPTION
The 'disableDatagram' property is not used by the Model so removed it
along with getter. Also fixed use within RunTask to call get method to
actually get the value. Didn't realize the fields within the RunTask
were not set.

TESTED:
- Set httpPort to one that was currently being used by UDP and observed
  server fail to start due to port conflict even though disableDatagram
  was set within the appengine convention. Added some debug statements
  and discovered that needed to call getDisableDatagram to set the
  field. After that server started.