### PR TITLE
Add travis-ci.org CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+
+jdk:
+  - oraclejdk7
+  - openjdk7


### PR DESCRIPTION
Add travis-ci.org continuous integration configuration for java-gradle builds

More info at : http://docs.travis-ci.com/user/languages/java/ (scroll to gradle)