### PR TITLE
add deprecation to messaging

### DIFF
--- a/GCLOUD.md
+++ b/GCLOUD.md
@@ -1,6 +1,8 @@
 ![Google Cloud Platform Logo](https://cloud.google.com/_static/images/gcp-logo.png)
 # Gradle GCloud [preview] Plugin
 
+*This plugin is deprecated and may not work for you, try using gcloud directly*
+
 This plugin provides tasks for running and deploying App Engine applications using the gcloud command line tool.
 *Caution:* This plugin is experimental and may change without notice
 

--- a/src/main/groovy/com/google/gcloud/task/app/DeployTask.groovy
+++ b/src/main/groovy/com/google/gcloud/task/app/DeployTask.groovy
@@ -25,7 +25,7 @@ class DeployTask extends AppTask {
 
     @Override
     List<String> getCommand() {
-        ['preview','app','deploy']
+        ['app','deploy']
     }
 
     @Override


### PR DESCRIPTION
- also fixes the gcloud command just in case.
- run will always fail now because app run is gone.