### PR TITLE
Rollback will use exploded war directory

### DIFF
--- a/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
+++ b/src/main/groovy/com/google/appengine/AppEnginePlugin.groovy
@@ -146,7 +146,7 @@ class AppEnginePlugin implements Plugin<Project> {
         configureRun(project, appEnginePluginExtension, explodedAppDirectory)
         configureStop(project, appEnginePluginExtension)
         configureUpdate(project, appEnginePluginExtension, explodedAppDirectory)
-        configureRollback(project)
+        configureRollback(project, explodedAppDirectory)
         configureSdk(project, appEnginePluginExtension)
         configureEnhance(project, appEnginePluginExtension)
         configureUpdateIndexes(project)
@@ -373,10 +373,15 @@ class AppEnginePlugin implements Plugin<Project> {
         appengineUpdateTask.dependsOn project.appengineExplodeApp
     }
 
-    private void configureRollback(Project project) {
+    private void configureRollback(Project project, File explodedWarDirectory) {
+        project.tasks.withType(RollbackTask).whenTaskAdded { RollbackTask appengineRollbackTask ->
+            appengineRollbackTask.conventionMapping.map(EXPLODED_WAR_DIR_CONVENTION_PARAM) { explodedWarDirectory }
+        }
+
         RollbackTask appengineRollbackTask = project.tasks.create(APPENGINE_ROLLBACK, RollbackTask)
         appengineRollbackTask.description = 'Undoes a partially completed update for the given application.'
         appengineRollbackTask.group = APPENGINE_GROUP
+        appengineRollbackTask.dependsOn project.appengineExplodeApp
     }
 
     private void configureSetDefaultVersionTask(Project project, File explodedAppDirectory) {

--- a/src/main/groovy/com/google/appengine/task/appcfg/RollbackTask.groovy
+++ b/src/main/groovy/com/google/appengine/task/appcfg/RollbackTask.groovy
@@ -15,6 +15,8 @@
  */
 package com.google.appengine.task.appcfg
 
+import org.gradle.api.tasks.InputDirectory
+
 /**
  * Google App Engine task undoing a partially completed update for the given application.
  *
@@ -22,6 +24,7 @@ package com.google.appengine.task.appcfg
  */
 class RollbackTask extends AppConfigTaskTemplate {
     static final String COMMAND = 'rollback'
+    @InputDirectory File explodedAppDirectory
 
     @Override
     String startLogMessage() {
@@ -40,6 +43,6 @@ class RollbackTask extends AppConfigTaskTemplate {
 
     @Override
     List getParams() {
-        [COMMAND, getWebAppSourceDirectory().canonicalPath]
+        [COMMAND, getExplodedAppDirectory().canonicalPath]
     }
 }


### PR DESCRIPTION
Rollback will use exploded war directory to able to rollback when using variants (mentioned in #177)